### PR TITLE
chore: cleanup and client option to destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ description:
 openvpn:
   subnet: aaa.bbb.ccc.ddd
   netmask: lll.mmm.nnn.ooo
-  client: true # or false
+  destination: 'client' # or 'server'
 ```
 
 Note: I found that even though the ansible documentation says that groups.all and groups.ungrouped will give you all of the servers, unless I added my connected systems to a group, the servers were not listed in either group.

--- a/templates/easy_ovpn/client.conf.j2
+++ b/templates/easy_ovpn/client.conf.j2
@@ -11,8 +11,8 @@ resolv-retry infinite
 nobind
 persist-key
 persist-tun
-comp-lzo
 verb 3
+
 key-direction 1
 remote-cert-tls server
 tls-client

--- a/templates/easy_ovpn/client.conf.j2
+++ b/templates/easy_ovpn/client.conf.j2
@@ -24,8 +24,14 @@ tls-cipher "TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256:TLS-ECDHE-ECDSA-WITH-AES-128-G
 {% if inventory_hostname == 'localhost' %}
 # Connected Systems for localhost client
 {% for h in groups.all %}
-{% if hostvars[h].openvpn is defined and hostvars[h].openvpn.subnet is defined and hostvars[h].openvpn.netmask is defined and hostvars[h].openvpn.client == true %}
+{% if hostvars[h].openvpn is defined %}
+{% if hostvars[h].openvpn.subnet is undefined %}
+# no subnet -- {{ hostvars[h].description }}
+{% elif hostvars[h].openvpn.netmask is undefined %}
+# no netmask -- {{ hostvars[h].description }}
+{% elif hostvars[h].openvpn.destination == 'client' %}
 route {{ hostvars[h].openvpn.subnet }} {{ hostvars[h].openvpn.netmask }} # {{ hostvars[h].description }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -38,7 +38,7 @@ management localhost 7505
 # no subnet -- {{ hostvars[h].description }}
 {% elif hostvars[h].openvpn.netmask is undefined %}
 # no netmask -- {{ hostvars[h].description }}
-{% elif hostvars[h].openvpn.client != true %}
+{% elif hostvars[h].openvpn.destination == 'server' %}
 push "route {{ hostvars[h].openvpn.subnet }} {{ hostvars[h].openvpn.netmask }}" # {{ hostvars[h].description }}
 {% endif %}
 {% endif %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -33,16 +33,19 @@ management localhost 7505
 
 # Connected Systems
 {% for h in groups.all %}
-{% if hostvars[h].openvpn is defined and hostvars[h].openvpn.subnet is defined and hostvars[h].openvpn.netmask is defined and hostvars[h].openvpn.client != true %}
+{% if hostvars[h].openvpn is defined %}
+{% if hostvars[h].openvpn.subnet is undefined %}
+# no subnet -- {{ hostvars[h].description }}
+{% elif hostvars[h].openvpn.netmask is undefined %}
+# no netmask -- {{ hostvars[h].description }}
+{% elif hostvars[h].openvpn.client != true %}
 push "route {{ hostvars[h].openvpn.subnet }} {{ hostvars[h].openvpn.netmask }}" # {{ hostvars[h].description }}
+{% endif %}
 {% endif %}
 {% endfor %}
 
 client-to-client
 keepalive 10 120
-comp-lzo
-user nobody
-group nogroup
 persist-key
 persist-tun
 status /var/log/openvpn-status.log


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Chore

#### Changed behavior
Handling deprecations
Changed `client` option to `destination`.  Building a client configuration could be expanded to a set of configs depending on where the user is located.  Our case is on-site vs. offsite, requiring a different configuration to force routes through the vpn.  This is a step towards different configurations. 

#### PivotalTracker Stories
[#000000000](https://www.pivotaltracker.com/story/show/000000000)


#### Other information, known issues


#### Tests


#### Remaining Tasks
