### PR TITLE
chore: delegate to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,14 @@ vpn_server_group_name   Name of Ansible group of servers that are configured as 
 dns_servers             Inventory Group that will be included in dns list
                         Inventory entry must also have an ip_address variable
 cert_config
-    cn
-    country         Country for the cert
-    locality        Locality for the cert
-    state           State for the cert
-    organization    Organization for the cert
-    ou              Organizational Unit for the cert
-    email           Email for the cert
-    cn              Common name for the cert, usually fqdn
-    dc              Domain Component for the cert, if any
-
+    country         Country
+    locality        Locality
+    state           State
+    organization    Organization
+    ou              Organizational Unit
+    email           Email
+    cn              Common name, usually fqdn
+    dc              Domain Component, if any
 ```
 
 ## Tags/Flags

--- a/tasks/client_cert_generate.yml
+++ b/tasks/client_cert_generate.yml
@@ -19,11 +19,11 @@
 - name: Set target_fqdn from local_hostname when set
   set_fact:
     target_fqdn: "{{ local_hostname }}"
-  connection: local
+  delegate_to: localhost
   when: target_host == 'localhost' and local_hostname | length > 0
 
 - shell: hostname
-  connection: local
+  delegate_to: localhost
   register: host_long
   when: target_host == 'localhost' and local_hostname | length == 0
 
@@ -37,7 +37,7 @@
     cert_filename: "{{ target_fqdn }}.ovpn"
 
 - name: Check to see if file exists
-  connection: local
+  delegate_to: localhost
   stat:
     path: "{{ ovpn_base }}/certs/{{ cert_filename }}"
   register: cert_stat
@@ -150,7 +150,7 @@
   file:
     path: "{{ ovpn_base }}/certs"
     state: directory
-  connection: local
+  delegate_to: localhost
   when: need_generate
 
 - name: Pull the certificate file to localhost

--- a/tasks/client_cert_generate.yml
+++ b/tasks/client_cert_generate.yml
@@ -13,7 +13,7 @@
 
 - name: Set target_fqdn when target_host is not localhost
   set_fact:
-    target_fqdn: "{{ target_vars.server_fqdn }}"
+    target_fqdn: "{{ target_vars.fqdn }}"
   when: target_host != 'localhost'
 
 - name: Set target_fqdn from local_hostname when set

--- a/tasks/client_deploy.yml
+++ b/tasks/client_deploy.yml
@@ -8,8 +8,8 @@
 
 - name: Basic Facts
   set_fact:
-    cert_filename: "{{ server_fqdn }}.ovpn"
-    client_file: "/etc/openvpn/{{ server_fqdn }}.conf"
+    cert_filename: "{{ fqdn }}.ovpn"
+    client_file: "/etc/openvpn/{{ fqdn }}.conf"
 
 - name: copy certificate file to target
   become: true

--- a/tasks/server_cert_pull.yml
+++ b/tasks/server_cert_pull.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ ovpn_base }}/server"
     state: directory
-  connection: local
+  delegate_to: localhost
 
 - name: Copy files to local directory
   synchronize:

--- a/templates/easy_ovpn/client.conf.j2
+++ b/templates/easy_ovpn/client.conf.j2
@@ -3,7 +3,7 @@ dev tun
 proto udp
 
 {% for h in groups[vpn_server_group_name]  %}
-remote {{ hostvars[h].server_fqdn }} 1194
+remote {{ hostvars[h].fqdn }} 1194
 {% endfor %}
 
 remote-random


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Chore

#### Changed behavior

Use `delegate_to: localhost` instead of `connection: local` due to `ansible` requirements.

#### Breaking Changes
* `server_fqdn` to `fqdn`



